### PR TITLE
Feature/revocation data loader

### DIFF
--- a/cert-validation/pom.xml
+++ b/cert-validation/pom.xml
@@ -6,6 +6,7 @@
 
   <artifactId>cert-validation</artifactId>
   <packaging>jar</packaging>
+  <version>1.0.2-SNAPSHOT</version>
 
   <parent>
     <artifactId>sigval-base-parent</artifactId>
@@ -62,7 +63,7 @@
     <dependency>
       <groupId>se.idsec.sigval.base</groupId>
       <artifactId>cert-extensions</artifactId>
-      <version>${project.version}</version>
+      <version>1.0.1</version>
     </dependency>
 
     <dependency>

--- a/cert-validation/src/main/java/se/idsec/sigval/cert/chain/AbstractPathValidator.java
+++ b/cert-validation/src/main/java/se/idsec/sigval/cert/chain/AbstractPathValidator.java
@@ -17,6 +17,8 @@ package se.idsec.sigval.cert.chain;
 
 import lombok.Setter;
 import se.idsec.signservice.security.certificate.CertificateValidationResult;
+import se.idsec.sigval.cert.chain.impl.CertificatePathValidatorFactory;
+import se.idsec.sigval.cert.chain.impl.CertificateValidityCheckerFactory;
 import se.idsec.sigval.cert.validity.crl.CRLCache;
 
 import java.beans.PropertyChangeEvent;
@@ -53,7 +55,11 @@ import java.util.List;
  */
 public abstract class AbstractPathValidator implements Runnable {
 
+  public static final String DEFAULT_EVENT_ID = "certPathValidator";
   private final List<PropertyChangeListener> listeners;
+  /** Provides the certificate validation checker for each instance of certificate validation */
+  @Setter protected CertificateValidityCheckerFactory certificateValidityCheckerFactory;
+
   /**
    * The id of the event being communicated back to registered property change listeners as property name
    *
@@ -116,4 +122,5 @@ public abstract class AbstractPathValidator implements Runnable {
    * @throws ExtendedCertPathValidatorException errors encountered while validation certificate path
    */
   public abstract PathValidationResult validateCertificatePath() throws ExtendedCertPathValidatorException;
+
 }

--- a/cert-validation/src/main/java/se/idsec/sigval/cert/chain/impl/CertificatePathValidatorFactory.java
+++ b/cert-validation/src/main/java/se/idsec/sigval/cert/chain/impl/CertificatePathValidatorFactory.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2021. IDsec Solutions AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package se.idsec.sigval.cert.chain.impl;
+
+import se.idsec.sigval.cert.chain.AbstractPathValidator;
+import se.idsec.sigval.cert.validity.crl.CRLCache;
+
+import java.security.cert.CertStore;
+import java.security.cert.TrustAnchor;
+import java.security.cert.X509Certificate;
+import java.util.List;
+
+public interface CertificatePathValidatorFactory {
+
+  AbstractPathValidator getPathValidator (X509Certificate targetCert, List<X509Certificate> chain,
+    List<TrustAnchor> trustAnchors, CertStore certStore, CRLCache crlCache);
+}

--- a/cert-validation/src/main/java/se/idsec/sigval/cert/chain/impl/CertificateValidityCheckerFactory.java
+++ b/cert-validation/src/main/java/se/idsec/sigval/cert/chain/impl/CertificateValidityCheckerFactory.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2021. IDsec Solutions AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package se.idsec.sigval.cert.chain.impl;
+
+import se.idsec.sigval.cert.validity.CertificateValidityChecker;
+import se.idsec.sigval.cert.validity.crl.CRLCache;
+
+import java.beans.PropertyChangeListener;
+import java.security.cert.X509Certificate;
+
+public interface CertificateValidityCheckerFactory {
+
+  CertificateValidityChecker getCertificateValidityChecker(X509Certificate certificate, X509Certificate issuer, CRLCache crlCache, PropertyChangeListener... propertyChangeListeners);
+}

--- a/cert-validation/src/main/java/se/idsec/sigval/cert/validity/AbstractValidityChecker.java
+++ b/cert-validation/src/main/java/se/idsec/sigval/cert/validity/AbstractValidityChecker.java
@@ -38,7 +38,7 @@ public abstract class AbstractValidityChecker implements ValidityChecker {
   /**
    * Constructor
    * @param certificate the target certificate being validated
-   * @param issuer issuer certificate for the CA issuign the target certificate
+   * @param issuer issuer certificate for the CA issuing the target certificate
    * @param id event id being returned as the property name to registered listeners.
    * @param propertyChangeListeners optional listeners when performing validation as a {@link Runnable} class
    */

--- a/cert-validation/src/main/java/se/idsec/sigval/cert/validity/CertificateValidityChecker.java
+++ b/cert-validation/src/main/java/se/idsec/sigval/cert/validity/CertificateValidityChecker.java
@@ -41,22 +41,25 @@ import java.util.List;
  */
 public abstract class CertificateValidityChecker implements Runnable, PropertyChangeListener{
 
+  public static final String EVENT_ID = "cert-validity";
   private List<PropertyChangeListener> listeners;
-  private String id;
+  private final String id;
   protected List<ValidityChecker> validityCheckers;
   protected ValidityPathChecker validityPathChecker;
-  protected X509Certificate certificate;
-  protected X509Certificate issuer;
+  protected final X509Certificate certificate;
+  protected final X509Certificate issuer;
 
   public CertificateValidityChecker(
     X509Certificate certificate,
     X509Certificate issuer,
     String id,
+    ValidityPathChecker validityPathChecker,
     PropertyChangeListener... propertyChangeListeners) {
 
     this.certificate = certificate;
     this.issuer = issuer;
     this.id = id;
+    this.validityPathChecker = validityPathChecker;
     this.listeners = Arrays.asList(propertyChangeListeners);
   }
 
@@ -66,6 +69,14 @@ public abstract class CertificateValidityChecker implements Runnable, PropertyCh
    */
   public void setValidityCheckers(List<ValidityChecker> validityCheckers) {
     this.validityCheckers = validityCheckers;
+  }
+
+  /**
+   * Getter for validity checkers used to check validity status
+   * @return validity checkers
+   */
+  public List<ValidityChecker> getValidityCheckers() {
+    return validityCheckers;
   }
 
   /**

--- a/cert-validation/src/main/java/se/idsec/sigval/cert/validity/ValidationStatus.java
+++ b/cert-validation/src/main/java/se/idsec/sigval/cert/validity/ValidationStatus.java
@@ -100,8 +100,8 @@ public class ValidationStatus {
   private List<X509Certificate> statusSignerCertificateChain;
   /** Indicates if the signature on validation status data is valid and verifies against the specified status signer certificate */
   private boolean statusSignatureValid;
-  /** Indication of a reason for revocation provided as string for display purpose only */
-  private String reason;
+  /** Indication of a reason for revocation according to RFC 5280 */
+  private int reason;
   /** Exception thrown during validation checking */
   private Exception exception;
 

--- a/cert-validation/src/main/java/se/idsec/sigval/cert/validity/crl/CRLCache.java
+++ b/cert-validation/src/main/java/se/idsec/sigval/cert/validity/crl/CRLCache.java
@@ -19,6 +19,7 @@ package se.idsec.sigval.cert.validity.crl;
 import java.io.IOException;
 
 import org.bouncycastle.asn1.x509.CRLDistPoint;
+import se.idsec.sigval.cert.validity.crl.impl.CRLDataLoader;
 
 /**
  * CRL Cache interface
@@ -49,4 +50,5 @@ public interface CRLCache {
    * Update the current cache. Implementations of this function must be thread safe, allowing use of the CRL cache while it is being updated.
    */
   void recache();
+
 }

--- a/cert-validation/src/main/java/se/idsec/sigval/cert/validity/crl/impl/CRLDataLoader.java
+++ b/cert-validation/src/main/java/se/idsec/sigval/cert/validity/crl/impl/CRLDataLoader.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2021. IDsec Solutions AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package se.idsec.sigval.cert.validity.crl.impl;
+
+import java.io.IOException;
+
+public interface CRLDataLoader {
+
+  /**
+   * Download CRL data
+   * @param url URL from which the CRL is to be downloaded
+   * @param connectTimeout timeout in milliseconds for connecting to the CRL source
+   * @param readTimeout timout in milliseconds for reading the CRL data
+   * @return CRL bytes
+   * @throws IOException on errors downloading the CRL
+   */
+  byte[] downloadCrl(String url, int connectTimeout, int readTimeout) throws IOException;
+}

--- a/cert-validation/src/main/java/se/idsec/sigval/cert/validity/crl/impl/CRLValidityChecker.java
+++ b/cert-validation/src/main/java/se/idsec/sigval/cert/validity/crl/impl/CRLValidityChecker.java
@@ -76,7 +76,7 @@ public class CRLValidityChecker extends AbstractValidityChecker {
         builder.revocationTime(crlEntry.getRevocationDate());
         CRLReason reason = crlEntry.getRevocationReason();
         if (reason != null) {
-          builder.reason(reason.name());
+          builder.reason(getReasonCode(reason));
           log.debug("The certificate was revoked with reason: " + reason.name());
         }
       }
@@ -89,6 +89,48 @@ public class CRLValidityChecker extends AbstractValidityChecker {
       builder.exception(ex);
     }
     return builder.build();
+  }
+
+  private int getReasonCode(CRLReason reason) {
+    /**
+     The CRLReason enumeration.
+     CRLReason ::= ENUMERATED {
+     unspecified             (0),
+     keyCompromise           (1),
+     cACompromise            (2),
+     affiliationChanged      (3),
+     superseded              (4),
+     cessationOfOperation    (5),
+     certificateHold         (6),
+     removeFromCRL           (8),
+     privilegeWithdrawn      (9),
+     aACompromise           (10)
+     }
+     */
+
+    switch (reason){
+
+    case KEY_COMPROMISE:
+      return 1;
+    case CA_COMPROMISE:
+      return 2;
+    case AFFILIATION_CHANGED:
+      return 3;
+    case SUPERSEDED:
+      return 4;
+    case CESSATION_OF_OPERATION:
+      return 5;
+    case CERTIFICATE_HOLD:
+      return 6;
+    case REMOVE_FROM_CRL:
+      return 8;
+    case PRIVILEGE_WITHDRAWN:
+      return 9;
+    case AA_COMPROMISE:
+      return 10;
+    default:
+      return 0;
+    }
   }
 
 }

--- a/cert-validation/src/main/java/se/idsec/sigval/cert/validity/impl/BasicCertificateValidityChecker.java
+++ b/cert-validation/src/main/java/se/idsec/sigval/cert/validity/impl/BasicCertificateValidityChecker.java
@@ -43,7 +43,6 @@ import java.util.stream.Collectors;
 @Slf4j
 public class BasicCertificateValidityChecker extends CertificateValidityChecker {
 
-  public static final String EVENT_ID = "cert-validity";
   /**
    * Gets the resulting validation results for CRL and OCSP
    *
@@ -70,12 +69,11 @@ public class BasicCertificateValidityChecker extends CertificateValidityChecker 
    */
   public BasicCertificateValidityChecker(X509Certificate certificate, X509Certificate issuer, CRLCache crlCache,
     PropertyChangeListener... propertyChangeListeners) {
-    super(certificate, issuer, EVENT_ID, propertyChangeListeners);
+    super(certificate, issuer, EVENT_ID, new BasicValidityPathChecker(crlCache), propertyChangeListeners);
     this.setValidityCheckers(Arrays.asList(
       new CRLValidityChecker(certificate, issuer, crlCache, this),
       new OCSPCertificateVerifier(certificate, issuer, this)
     ));
-    this.setValidityPathChecker(new BasicValidityPathChecker(crlCache));
   }
 
   /**

--- a/cert-validation/src/main/java/se/idsec/sigval/cert/validity/impl/BasicValidityPathChecker.java
+++ b/cert-validation/src/main/java/se/idsec/sigval/cert/validity/impl/BasicValidityPathChecker.java
@@ -136,6 +136,8 @@ public class BasicValidityPathChecker implements ValidityPathChecker {
     try {
       if (issuer.equals(statusSignerCertificate)){
         log.debug("The target cert issuer is also the OCSP response issuer {}", issuer.getSubjectX500Principal());
+        // When this is the case, then no further checks on certificate content is needed.
+        return;
       } else {
         statusSignerCertificate.verify(issuer.getPublicKey());
         log.debug("The OCSP certificate {} is issued by the CA that issued the target certificate", statusSignerCertificate.getSubjectX500Principal());

--- a/cert-validation/src/main/java/se/idsec/sigval/cert/validity/ocsp/OCSPCertificateVerifier.java
+++ b/cert-validation/src/main/java/se/idsec/sigval/cert/validity/ocsp/OCSPCertificateVerifier.java
@@ -172,10 +172,12 @@ public class OCSPCertificateVerifier extends AbstractValidityChecker implements 
               status.setValidity(CertificateValidity.VALID);
             }
             else {
-              Date revocationDate = ((RevokedStatus) singleResp.getCertStatus()).getRevocationTime();
+              RevokedStatus revokedStatus = (RevokedStatus) singleResp.getCertStatus();
+              Date revocationDate = revokedStatus.getRevocationTime();
               log.debug("OCSP for certificate '{}' is revoked since {}", subject, revocationDate);
               status.setRevocationTime(revocationDate);
               status.setRevocationObjectIssuingTime(singleResp.getThisUpdate());
+              status.setReason(revokedStatus.getRevocationReason());
               status.setValidity(CertificateValidity.REVOKED);
             }
           }
@@ -274,7 +276,8 @@ public class OCSPCertificateVerifier extends AbstractValidityChecker implements 
     Extensions extensions = (nonce == null)
       ? null
       : new Extensions(new Extension(OCSPObjectIdentifiers.id_pkix_ocsp_nonce, false, nonce));
-    ocspReqGenerator.addRequest(certificateId, extensions);
+    ocspReqGenerator.addRequest(certificateId);
+    ocspReqGenerator.setRequestExtensions(extensions);
     return ocspReqGenerator.build();
   }
 

--- a/cert-validation/src/main/java/se/idsec/sigval/cert/validity/ocsp/OCSPDataLoader.java
+++ b/cert-validation/src/main/java/se/idsec/sigval/cert/validity/ocsp/OCSPDataLoader.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2021. IDsec Solutions AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package se.idsec.sigval.cert.validity.ocsp;
+
+import org.bouncycastle.cert.ocsp.OCSPReq;
+import org.bouncycastle.cert.ocsp.OCSPResp;
+
+import java.io.IOException;
+
+public interface OCSPDataLoader {
+
+  /**
+   * Get an OCSP response from the
+   * @param url
+   * @param ocspReq
+   * @return
+   * @throws IOException
+   */
+  OCSPResp requestOCSPResponse(String url, OCSPReq ocspReq, int connectTimeout, int readTimeout) throws IOException;
+}


### PR DESCRIPTION
Provides the following updates to the certificate validation code:

- Implements an interface for loading data when checking CRL and OCSP. This allows usage of these classes in test environments where data loading is provided by a local resource.
- Fixed a bug that requires a CA certificate to include the OCSP eku OID even if the OCSP response is issed directly under the CA certificate